### PR TITLE
[LAR-2]: Basic component handling with cmakefiles added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ XUNIT_RESULT*.xml
 
 sdkconfig
 sdkconfig.defaults
+warnings.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,5 +4,12 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
+# Basic, but works for now.
+# I'll probably need to scrap this rather sooner than later. 
+# Assigned Task LAR-5?
+
+set(EXTRA_COMPONENT_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/components/booters ${CMAKE_CURRENT_SOURCE_DIR}/components/mounters ${CMAKE_CURRENT_SOURCE_DIR}/components)
+set(COMPONENTS main ${EXTRA_COMPONENT_DIRS})
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(main)

--- a/components/booters/example_ct2/CMakeLists.txt
+++ b/components/booters/example_ct2/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "example_ct2.c"
+                    INCLUDE_DIRS ".")

--- a/components/booters/example_ct2/example_ct2.c
+++ b/components/booters/example_ct2/example_ct2.c
@@ -1,0 +1,12 @@
+#include "esp_log.h"
+
+// Lazy way to avoid spending time on previous definition errors
+// But I spend some time to make it work without adding more time building thanks to the extension
+// I'll figure this one out later
+
+const char *TAG1 = "Booters";
+
+void print_message_component_two(void) 
+{
+    ESP_LOGI(TAG1, "Hello from Ct2! Booters will go here..");
+}

--- a/components/mounters/example_ct1/CMakeLists.txt
+++ b/components/mounters/example_ct1/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "example_ct1.c"
+                    INCLUDE_DIRS "." "include")

--- a/components/mounters/example_ct1/example_ct1.c
+++ b/components/mounters/example_ct1/example_ct1.c
@@ -1,0 +1,13 @@
+#include "example_ct1.h"
+#include "esp_log.h"
+
+// Lazy way to avoid spending time on previous definition errors
+// But I spend some time to make it work without adding more time building thanks to the extension
+// I'll figure this one out later
+
+static const char *TAG2 = "Mounters";
+
+void print_message_component_one(void) 
+{
+    ESP_LOGI(TAG2, "Hello from Ct1! Mounters will go here..");
+}

--- a/components/mounters/example_ct1/include/example_ct1.h
+++ b/components/mounters/example_ct1/include/example_ct1.h
@@ -1,0 +1,1 @@
+void print_message_component_one(void);

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "main.c"
-                    INCLUDE_DIRS ".")
+                    INCLUDE_DIRS "." "../components"
+                    REQUIRES example_ct1 example_ct2 driver)

--- a/main/main.c
+++ b/main/main.c
@@ -4,6 +4,8 @@
 #include "esp_log.h"
 #include "portmacro.h"
 #include "sdkconfig.h"
+#include "example_ct1.h"
+#include "example_ct2.c"
 
 static const char *TAG = "example";
 
@@ -29,6 +31,8 @@ void app_main(void)
     while(1)
     {
         ESP_LOGI(TAG, "Turning the LED %s!", s_led_state == true ? "ON" : "OFF");
+        print_message_component_one();
+        print_message_component_two();
         blink_led();
         s_led_state = !s_led_state;
         vTaskDelay(CONFIG_BLINK_PERIOD / portTICK_PERIOD_MS);


### PR DESCRIPTION
Basic component handling added with CMame, because handling components with the ESP-IDF opens up scenarios that I will not deal with. 

Still needs some work. I'll probably deal with it in future.